### PR TITLE
Remove noisy os.system call from TorchAudioLoader

### DIFF
--- a/webdataset/autodecode.py
+++ b/webdataset/autodecode.py
@@ -93,7 +93,6 @@ class TorchAudioLoader:
             fname = os.path.join(dirname, f"file.{self.extension}")
             with open(fname, "wb") as stream:
                 stream.write(data)
-            os.system(f"ls -l {fname}")
             return torchaudio.load(fname, **self.kw)
 
 


### PR DESCRIPTION
This is pretty spammy in logs and other similar classes don't do it.