### PR TITLE
Include cache args in Dataset init

### DIFF
--- a/webdataset/fluid.py
+++ b/webdataset/fluid.py
@@ -16,9 +16,15 @@ from torch.utils.data import IterableDataset
 from . import autodecode
 from . import iterators
 from . import tariterators
-from . import dataset
+from .dataset import (
+    WebDataset,
+    split_by_worker,
+    default_cache_dir,
+    default_cache_name,
+    default_cache_size,
+    default_cache_verbose
+)
 from .utils import reraise_exception
-
 
 
 class Dataset(IterableDataset):
@@ -27,16 +33,16 @@ class Dataset(IterableDataset):
         urls,
         *,
         length=True,
-        splitter=dataset.split_by_worker,
+        splitter=split_by_worker,
         handler=reraise_exception,
         shuffle=False,
-        cache_dir=dataset.default_cache_dir,
-        cache_size=dataset.default_cache_size,
-        cache_name=dataset.default_cache_name,
-        cache_verbose=dataset.default_cache_verbose
+        cache_dir=default_cache_dir,
+        cache_size=default_cache_size,
+        cache_name=default_cache_name,
+        cache_verbose=default_cache_verbose
     ):
         super().__init__()
-        self.dataset = dataset.WebDataset(
+        self.dataset = WebDataset(
             urls,
             shardshuffle=shuffle,
             splitter=splitter,

--- a/webdataset/fluid.py
+++ b/webdataset/fluid.py
@@ -48,7 +48,6 @@ class Dataset(IterableDataset):
             cache_verbose=cache_verbose
         )
 
-
     def __getattr__(self, name):
         if not hasattr(self.dataset, name):
             raise AttributeError()

--- a/webdataset/fluid.py
+++ b/webdataset/fluid.py
@@ -42,7 +42,7 @@ class Dataset(IterableDataset):
         cache_verbose=default_cache_verbose
     ):
         super().__init__()
-        self.dataset = WebDataset(
+        self._dataset = WebDataset(
             urls,
             shardshuffle=shuffle,
             splitter=splitter,
@@ -55,15 +55,15 @@ class Dataset(IterableDataset):
         )
 
     def __getattr__(self, name):
-        if not hasattr(self.dataset, name):
+        if not hasattr(self._dataset, name):
             raise AttributeError()
         def f(*args, **kw):
-            self.dataset = getattr(self.dataset, name)(*args, **kw)
+            self._dataset = getattr(self._dataset, name)(*args, **kw)
             return self
         return f
 
     def __iter__(self):
-        return iter(self.dataset)
+        return iter(self._dataset)
 
     def __len__(self):
-        return len(self.dataset)
+        return len(self._dataset)

--- a/webdataset/fluid.py
+++ b/webdataset/fluid.py
@@ -30,6 +30,10 @@ class Dataset(IterableDataset):
         splitter=dataset.split_by_worker,
         handler=reraise_exception,
         shuffle=False,
+        cache_dir=dataset.default_cache_dir,
+        cache_size=dataset.default_cache_size,
+        cache_name=dataset.default_cache_name,
+        cache_verbose=dataset.default_cache_verbose
     ):
         super().__init__()
         self.dataset = dataset.WebDataset(
@@ -38,7 +42,12 @@ class Dataset(IterableDataset):
             splitter=splitter,
             handler=handler,
             length=length,
+            cache_dir=cache_dir,
+            cache_size=cache_size,
+            cache_name=cache_name,
+            cache_verbose=cache_verbose
         )
+
 
     def __getattr__(self, name):
         if not hasattr(self.dataset, name):


### PR DESCRIPTION
Fix mentioned in #50 . 

I figure the signature should match `wds.WebDataset` exactly so you can just use `**kwargs` instead of explicitly listing the args in `wds.Dataset`'s init. However, I opted to not do that since it would introduce breaking changes to the existing `wds.Dataset` API. 