### PR TITLE
collation_fn argument for batched + DBCache source_ fn

### DIFF
--- a/webdataset/dataset.py
+++ b/webdataset/dataset.py
@@ -166,8 +166,8 @@ class Shorthands:
     def __init__(self):
         super().__init__()
 
-    def batched(self, batchsize, partial=True):
-        return self.then(iterators.batched, batchsize=batchsize, partial=partial)
+    def batched(self, batchsize, collation_fn=iterators.default_collation_fn, partial=True):
+        return self.then(iterators.batched, batchsize=batchsize, collation_fn=collation_fn, partial=partial)
 
     def unbatched(self):
         return self.then(iterators.unbatched)

--- a/webdataset/dbcache.py
+++ b/webdataset/dbcache.py
@@ -31,6 +31,10 @@ class DBCache(IterableDataset):
         if self.verbose:
             print(f"[DBCache opened {dbname} size {self.size} total {self.total}]", file=sys.stderr, flush=True)
 
+    def source_(self, source):
+        self.source = source
+        return self
+    
     def __call__(self, source):
         self.source = source
         return self


### PR DESCRIPTION
Hey Tom! 

I've been using `webdataset` for managing our audio data pipeline and ran into a couple of blockers for our use case. 

## user-specified collation function
The first change is regarding the `.batched` function in the `Shorthands` class. In master, you cannot specify a collation function to use akin to what `torch.utils.data.DataLoader` allows. The actual function responsible with batching, `iterators.batched` allows for a user-specified collation function but this is not pushed into the `Shorthands` class. A couple of reasons why this is a good feature to have are allowing batched dictionaries, complicated padding strategies, in-batch ordering of elements, ...

## DBCache missing `source_` attr
The second change is adding the `.source_` function to the `DBCache` class. I was simply following the `readme.ipynb` and could not get the section with the sample caching work. By adding the changes, I can get the expected behavior of the class.
